### PR TITLE
Update web component version to 1.0.3

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 
 @SuppressWarnings("serial")
 @Tag("fc-whatsapp-button")
-@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "1.0.1")
+@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "1.0.3")
 @JsModule("@flowingcode/fc-whatsapp-button/dist/src/fc-whatsapp-button.js")
 public class WhatsappButton extends Component {
 


### PR DESCRIPTION
Update web component version to 1.0.3. This version contains a fix to exports tag in package.json to avoid issues when using the component in an application running with vite.