### PR TITLE
feat: version compatible with vaadin 24.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,21 @@
 
 	<groupId>org.vaadin.addons.flowingcode</groupId>
 	<artifactId>whatsapp-button-addon</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>Whatsapp Button Add-on</name>
 	<description>Whatsapp Button Add-on</description>
 
 	<properties>
-        <vaadin.version>23.1.7</vaadin.version>
-        <selenium.version>4.1.2</selenium.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<vaadin.version>24.4.4</vaadin.version>
+		<selenium.version>4.10.0</selenium.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<drivers.dir>${project.basedir}/drivers</drivers.dir>
-		<jetty.version>9.4.36.v20210114</jetty.version>
+		<jetty.version>11.0.20</jetty.version>
+		<flowingcode.commons.demo.version>4.0.0</flowingcode.commons.demo.version>
+		<frontend.hotdeploy>true</frontend.hotdeploy>
 	</properties>
 
 	<organization>
@@ -52,7 +54,7 @@
             <dependency>
             	<groupId>com.flowingcode.vaadin.addons.demo</groupId>
             	<artifactId>commons-demo</artifactId>
-            	<version>3.5.1</version>
+            	<version>${flowingcode.commons.demo.version}</version>
             </dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -203,7 +205,6 @@
             <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
 				<configuration>
 					<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
@@ -225,14 +226,14 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>${jetty.version}</version>
 				<configuration>
-					<scanIntervalSeconds>3</scanIntervalSeconds>
+					<scan>3</scan>
 					<!-- Use test scope because the UI/demo classes are in the test package. -->
 					<useTestScope>true</useTestScope>
-					<webAppConfig>
+					<webApp>
 						<resourceBases>
 							<resourceBase>src/test/resources/META-INF/resources</resourceBase>
 						</resourceBases>
-					</webAppConfig>
+					</webApp>
 					<supportedPackagings>
 						<supportedPackaging>jar</supportedPackaging>
 					</supportedPackagings>
@@ -480,27 +481,6 @@
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-		<profile>
-			<id>v24</id>
-			<properties>
-				<maven.compiler.source>17</maven.compiler.source>
-				<maven.compiler.target>17</maven.compiler.target>
-				<vaadin.version>24.2.6</vaadin.version>
-				<jetty.version>11.0.12</jetty.version>
-			</properties>
-			<repositories>
-				<repository>
-					<id>vaadin-prerelease</id>
-					<url>https://maven.vaadin.com/vaadin-prereleases</url>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>vaadin-prerelease</id>
-					<url>https://maven.vaadin.com/vaadin-prereleases</url>
-				</pluginRepository>
-			</pluginRepositories>
 		</profile>		
 	</profiles>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 
 @SuppressWarnings("serial")
 @Tag("fc-whatsapp-button")
-@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "1.0.3")
+@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "2.0.0")
 @JsModule("@flowingcode/fc-whatsapp-button/dist/src/fc-whatsapp-button.js")
 public class WhatsappButton extends Component {
 

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2021 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/DemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButtonDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButtonDemo.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Whatsapp Button Add-on
+ * %%
+ * Copyright (C) 2022 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.flowingcode.vaadin.addons.whatsappbutton;
 
 import com.flowingcode.vaadin.addons.demo.DemoSource;
@@ -19,7 +38,7 @@ import com.vaadin.flow.server.WebBrowser;
 import org.apache.commons.lang3.StringUtils;
 
 @DemoSource
-@PageTitle("Whatsapp Button Demo")
+@PageTitle("Whatsapp Button")
 @Route(value = "whatsappbutton/whatsappbutton", layout = WhatsappButtonDemoView.class)
 @SuppressWarnings("serial")
 public class WhatsappButtonDemo extends Div {

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButtonDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButtonDemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ package com.flowingcode.vaadin.addons.whatsappbutton;
 import com.flowingcode.vaadin.addons.DemoLayout;
 import com.flowingcode.vaadin.addons.GithubLink;
 import com.flowingcode.vaadin.addons.demo.TabbedDemo;
-import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 
@@ -30,7 +30,7 @@ import com.vaadin.flow.router.Route;
 @ParentLayout(DemoLayout.class)
 @Route("whatsappbutton")
 @GithubLink("https://github.com/FlowingCode/WhatsappButton")
-@StyleSheet("context://frontend/styles/whatsapp-button-demo-styles.css")
+@CssImport("./styles/whatsapp-button-demo-styles.css")
 public class WhatsappButtonDemoView extends TabbedDemo {
 
   public WhatsappButtonDemoView() {

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/it/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/it/AbstractViewTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/it/ViewIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/it/ViewIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/test/SerializationTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/whatsappbutton/test/SerializationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 Flowing Code
+ * Copyright (C) 2022 - 2024 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package com.flowingcode.vaadin.addons.whatsappbutton.test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/resources/META-INF/resources/frontend/styles/whatsapp-button-demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/whatsapp-button-demo-styles.css
@@ -1,4 +1,22 @@
-/*Demo styles*/
+/*-
+ * #%L
+ * Whatsapp Button Add-on
+ * %%
+ * Copyright (C) 2022 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 
 .button-container {
     margin: 40px 0;


### PR DESCRIPTION
Updates component to 24.4.4. Uses web-component version [2.0.0](https://github.com/FlowingCode/fc-whatsapp-button/releases/tag/2.0.0).

Also includes license header updates.

Close #14

