### PR TITLE
Update web-component dependency to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A simple button component to start Whatsapp conversations easily. It's based on 
 
 ## Online demo
 
-[Online demo here](http://addonsv23.flowingcode.com/whatsappbutton)
+[Online demo here](http://addonsv25.flowingcode.com/whatsappbutton)
 
 ## Download release
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.flowingcode</groupId>
 	<artifactId>whatsapp-button-addon</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>Whatsapp Button Add-on</name>
 	<description>Whatsapp Button Add-on</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,7 @@
 										<exclude>**/it/*</exclude>
 										<exclude>**/DemoView.class</exclude>
 										<exclude>**/DemoLayout.class</exclude>
+										<exclude>**/AppShellConfiguratorImpl.class</exclude>
 									</excludes>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
 			<properties>
 				<maven.compiler.source>21</maven.compiler.source>
 				<maven.compiler.target>21</maven.compiler.target>
-				<vaadin.version>25.0.0</vaadin.version>
+				<vaadin.version>25.0.3</vaadin.version>
 				<jetty.version>11.0.26</jetty.version>
 			</properties>
 			<dependencies>

--- a/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/whatsappbutton/WhatsappButton.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2026 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 
 @SuppressWarnings("serial")
 @Tag("fc-whatsapp-button")
-@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "2.0.0")
+@NpmPackage(value = "@flowingcode/fc-whatsapp-button", version = "2.1.0")
 @JsModule("@flowingcode/fc-whatsapp-button/dist/src/fc-whatsapp-button.js")
 public class WhatsappButton extends Component {
 

--- a/src/test/java/com/flowingcode/vaadin/addons/AppShellConfiguratorImpl.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/AppShellConfiguratorImpl.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * Whatsapp Button Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.Theme;
+
+@Theme
+public class AppShellConfiguratorImpl implements AppShellConfigurator {
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2026 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/resources/frontend/styles/whatsapp-button-demo-styles.css
+++ b/src/test/resources/META-INF/resources/frontend/styles/whatsapp-button-demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * Whatsapp Button Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2026 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR includes changes to fix #21 by updating the web-component dependency version to [2.1.0](https://github.com/FlowingCode/fc-whatsapp-button/releases/tag/2.1.0). This version includes a necessary refactor so styling is not broken in Vaadin 25.

Also, AppShellConfiguratorImpl was added and version is updated to 2.1.0-SNAPSHOT as the changes make the component compatible with Vaadin 24 & Vaadin 25.